### PR TITLE
Fix workflows for manifest

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -38,7 +38,7 @@ jobs:
           project_folder: "."
   post-merge-pipeline:
     needs: pre-checks
-    if: ${{ needs.pre-checks.outputs.filtered_projects != '[]' }}
+    if: ${{ needs.pre-checks.outputs.filtered_projects != '[]' && needs.pre-checks.outputs.filtered_projects != '[""]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/ena-manifest.yaml
+++ b/ena-manifest.yaml
@@ -10,7 +10,7 @@ repository:
   component: main
 packages:
   - name: cluster-agent
-    version: 1.6.1
+    version: 1.6.0
     ociArtifact: edge-orch/en/deb/cluster-agent
   - name: hardware-discovery-agent
     version: 1.6.0


### PR DESCRIPTION
Fixes GHA workflows for cases when only the ena-manifest.yaml file is updated in a PR. Modifies the if statement for primary workflows to also check the `filetered_projects` format expected when only the ena-manifest.yaml file is modified as well as cases where only a non-agent folder has been modified.