### PR TITLE
fix: GPU device detection when vendor info is missing

### DIFF
--- a/hardware-discovery-agent/internal/gpu/gpu.go
+++ b/hardware-discovery-agent/internal/gpu/gpu.go
@@ -20,11 +20,13 @@ type Gpu struct {
 	Features    []string
 }
 
+var infoNotFound string = "Not Available"
+
 func parseGpuDetails(gpuDevice, infoType string) []string {
 	gpuInfo := strings.Split(gpuDevice, infoType)
 	if len(gpuInfo) == 1 {
 		// Return empty string if infoType is not found
-		return []string{""}
+		return []string{infoNotFound}
 	}
 	return strings.Split(gpuInfo[1], "\n")
 }
@@ -50,10 +52,13 @@ func GetGpuList(executor utils.CmdExecutor) ([]*Gpu, error) {
 		description := parseGpuDetails(gpu, "description: ")
 
 		deviceFeatures := parseGpuDetails(gpu, "capabilities: ")
-		features := strings.Split(deviceFeatures[0], " ")
+		features := deviceFeatures
+		if features[0] != infoNotFound {
+			features = strings.Split(deviceFeatures[0], " ")
+		}
 
-		device := ""
-		if pciAddress != "" {
+		device := "Info Not Available"
+		if pciAddress != infoNotFound {
 			deviceInfo, err := utils.ReadFromCommand(executor, "lspci", "-v", "-s", pciAddress)
 			if err != nil {
 				return []*Gpu{}, fmt.Errorf("failed to read data from command; error: %v", err)

--- a/hardware-discovery-agent/internal/gpu/gpu_test.go
+++ b/hardware-discovery-agent/internal/gpu/gpu_test.go
@@ -32,6 +32,8 @@ var testDescription3 string = "PCI graphics card"
 var testFeatures1 []string = []string{"pm", "vga_controller", "bus_master", "cap_list", "rom", "fb"}
 var testFeatures2 []string = []string{"pciexpress", "msi", "pm", "bus_master", "cap_list"}
 var testFeatures3 []string = []string{"pciexpress", "msi", "pm", "bus_master", "cap_list"}
+var testNotFoundMsg string = "Not Available"
+var testNameNotFound string = "Info Not Available"
 
 func expectedOutput(expect []*gpu.Gpu, pci, prod, vendor, name, desc string, features []string) []*gpu.Gpu {
 	return append(expect, &gpu.Gpu{
@@ -83,8 +85,8 @@ func TestGetGpuListMultiDevicesSuccess(t *testing.T) {
 func TestGetGpuListEmptyPciInfo(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyPciInfo)
 	expect := []*gpu.Gpu{}
-	expect = expectedOutput(expect, "", testProduct1,
-		testVendor1, "", testDescription1, testFeatures1)
+	expect = expectedOutput(expect, testNotFoundMsg, testProduct1,
+		testVendor1, testNameNotFound, testDescription1, testFeatures1)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, expect, out)
@@ -93,7 +95,7 @@ func TestGetGpuListEmptyPciInfo(t *testing.T) {
 func TestGetGpuListEmptyProductName(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyProductName)
 	expect := []*gpu.Gpu{}
-	expect = expectedOutput(expect, testPciAddr1, "",
+	expect = expectedOutput(expect, testPciAddr1, testNotFoundMsg,
 		testVendor1, testName, testDescription1, testFeatures1)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
@@ -104,7 +106,7 @@ func TestGetGpuListEmptyVendor(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyVendorName)
 	expect := []*gpu.Gpu{}
 	expect = expectedOutput(expect, testPciAddr1, testProduct1,
-		"", testName, testDescription1, testFeatures1)
+		testNotFoundMsg, testName, testDescription1, testFeatures1)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, expect, out)
@@ -114,7 +116,7 @@ func TestGetGpuListEmptyDescription(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyDescription)
 	expect := []*gpu.Gpu{}
 	expect = expectedOutput(expect, testPciAddr1, testProduct1,
-		testVendor1, testName, "", testFeatures1)
+		testVendor1, testName, testNotFoundMsg, testFeatures1)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, expect, out)
@@ -124,7 +126,7 @@ func TestGetGpuListEmptyFeatures(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyFeatures)
 	expect := []*gpu.Gpu{}
 	expect = expectedOutput(expect, testPciAddr1, testProduct1,
-		testVendor1, testName, testDescription1, []string{""})
+		testVendor1, testName, testDescription1, []string{testNotFoundMsg})
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, expect, out)
@@ -134,7 +136,7 @@ func TestGetGpuListEmptyDeviceName(t *testing.T) {
 	out, err := gpu.GetGpuList(testCmdExecutorEmptyDeviceName)
 	expect := []*gpu.Gpu{}
 	expect = expectedOutput(expect, testPciAddr1, testProduct1,
-		testVendor1, "", testDescription1, testFeatures1)
+		testVendor1, testNameNotFound, testDescription1, testFeatures1)
 	assert.Nil(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, expect, out)

--- a/hardware-discovery-agent/test/data/mock_gpu_empty_description.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_empty_description.txt
@@ -1,0 +1,11 @@
+  *-display
+       product: Graphics Controller
+       vendor: Graphics
+       physical id: 0
+       bus info: pci@0000:03:00.0
+       version: 04
+       width: 32 bits
+       clock: 66MHz
+       capabilities: pm vga_controller bus_master cap_list rom fb
+       configuration: driver=mgag200 latency=64 maxlatency=32 mingnt=16
+       resources: irq:16 memory:91000000-91ffffff memory:92808000-9280bfff memory:92000000-927fffff memory:c0000-dffff

--- a/hardware-discovery-agent/test/data/mock_gpu_empty_features.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_empty_features.txt
@@ -1,0 +1,11 @@
+  *-display
+       description: VGA compatible controller
+       product: Graphics Controller
+       vendor: Graphics
+       physical id: 0
+       bus info: pci@0000:03:00.0
+       version: 04
+       width: 32 bits
+       clock: 66MHz
+       configuration: driver=mgag200 latency=64 maxlatency=32 mingnt=16
+       resources: irq:16 memory:91000000-91ffffff memory:92808000-9280bfff memory:92000000-927fffff memory:c0000-dffff

--- a/hardware-discovery-agent/test/data/mock_gpu_empty_pci_info.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_empty_pci_info.txt
@@ -1,0 +1,11 @@
+  *-display
+       description: VGA compatible controller
+       product: Graphics Controller
+       vendor: Graphics
+       physical id: 0
+       version: 04
+       width: 32 bits
+       clock: 66MHz
+       capabilities: pm vga_controller bus_master cap_list rom fb
+       configuration: driver=mgag200 latency=64 maxlatency=32 mingnt=16
+       resources: irq:16 memory:91000000-91ffffff memory:92808000-9280bfff memory:92000000-927fffff memory:c0000-dffff

--- a/hardware-discovery-agent/test/data/mock_gpu_empty_product.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_empty_product.txt
@@ -1,0 +1,11 @@
+  *-display
+       description: VGA compatible controller
+       vendor: Graphics
+       physical id: 0
+       bus info: pci@0000:03:00.0
+       version: 04
+       width: 32 bits
+       clock: 66MHz
+       capabilities: pm vga_controller bus_master cap_list rom fb
+       configuration: driver=mgag200 latency=64 maxlatency=32 mingnt=16
+       resources: irq:16 memory:91000000-91ffffff memory:92808000-9280bfff memory:92000000-927fffff memory:c0000-dffff

--- a/hardware-discovery-agent/test/data/mock_gpu_empty_vendor.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_empty_vendor.txt
@@ -1,0 +1,11 @@
+  *-display
+       description: VGA compatible controller
+       product: Graphics Controller
+       physical id: 0
+       bus info: pci@0000:03:00.0
+       version: 04
+       width: 32 bits
+       clock: 66MHz
+       capabilities: pm vga_controller bus_master cap_list rom fb
+       configuration: driver=mgag200 latency=64 maxlatency=32 mingnt=16
+       resources: irq:16 memory:91000000-91ffffff memory:92808000-9280bfff memory:92000000-927fffff memory:c0000-dffff

--- a/hardware-discovery-agent/test/data/mock_gpu_no_name.txt
+++ b/hardware-discovery-agent/test/data/mock_gpu_no_name.txt
@@ -1,0 +1,9 @@
+ (prog-if 00 [VGA controller])
+        DeviceName: Embedded Video
+        Subsystem: Graphics Controller
+        Flags: bus master, 66MHz, medium devsel, latency 64, IRQ 16, NUMA node 0
+        Memory at 91000000 (32-bit, prefetchable) [size=16M]
+        Memory at 92808000 (32-bit, non-prefetchable) [size=16K]
+        Memory at 92000000 (32-bit, non-prefetchable) [size=8M]
+        Expansion ROM at 000c0000 [virtual] [disabled] [size=128K]
+        Capabilities: [dc] Power Management version 3


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Updates the GPU device detection in the HW Discovery Agent to provide empty strings if certain device information cannot be found for GPU devices.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Unit tests updated to provide new test cases with missing device information. All new unit tests run and passing

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
