### PR TITLE
K3s airgap lw enic

### DIFF
--- a/cluster-agent/enic/Dockerfile
+++ b/cluster-agent/enic/Dockerfile
@@ -45,4 +45,10 @@ RUN envsubst < /etc/systemd/system/containerd.service.d/proxy.conf.template > /e
 RUN envsubst < /etc/systemd/system/docker.service.d/proxy.conf.template > /etc/systemd/system/docker.service.d/proxy.conf
 RUN envsubst < /etc/default/rke2-server.template > /etc/default/rke2-server
 
+# Install k3s package to enable air gap installs
+RUN mkdir -p /var/lib/rancher/k3s/agent/images/
+RUN curl -L -o /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.zst "https://github.com/k3s-io/k3s/releases/download/v1.33.0%2Bk3s1/k3s-airgap-images-amd64.tar.zst"
+RUN curl -L -o /usr/local/bin/k3s https://github.com/k3s-io/k3s/releases/download/v1.33.0%2Bk3s1/k3s && chmod +x /usr/local/bin/k3s
+RUN curl -L -o /opt/install.sh https://get.k3s.io && chmod +x /opt/install.sh
+
 RUN systemctl enable cluster-agent

--- a/cluster-agent/enic/enic-ss.yaml
+++ b/cluster-agent/enic/enic-ss.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: cluster-agent
     spec:
+      initContainers:
+      - name: init-copy
+        image: registry.espdprod.infra-host.com/edge-orch/cluster/cluster-agent:lw-enic
+        command: ["/bin/sh", "-c", "cp -r /var/lib/rancher/* /mnt/rancher-volume/"]
+        volumeMounts:
+        - name: rancher-volume
+          mountPath: /mnt/rancher-volume
       containers:
       - name: cluster-agent
         image: registry.espdprod.infra-host.com/edge-orch/cluster/cluster-agent:lw-enic


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

This PR Pre-installs k3s packages to lw-enic to enable air-gap mode tests. The version of k3s version is now fixed at v1.33.0-k3s1.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

This is verified in cluster-tests with the following combination
-  Use clusters from branch https://github.com/open-edge-platform/cluster-tests/tree/k3s-provider-intel and target “make k3s-deploy-verify”
- Use k3s-airgap branch of cluster-manager in cluster-tests by modifying the .test-dependicies.yaml file.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
