### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -29,6 +31,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -46,6 +50,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -63,6 +69,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -80,6 +88,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -97,6 +107,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -114,6 +126,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -131,6 +145,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -148,6 +164,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod][reporting-agent] "
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"  # This searches in .github/workflows directory
@@ -156,3 +174,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to introduce a cooldown period for Dependabot updates across multiple package ecosystems. The cooldown ensures that Dependabot will wait 7 days before creating new pull requests for dependencies, helping to reduce noise and PR churn.

Dependabot configuration enhancements:

* Added a `cooldown` setting with `default-days: 7` to each package ecosystem configuration, ensuring Dependabot waits 7 days between opening new PRs for dependency updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R15-R16) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R34-R35) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R53-R54) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R72-R73) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R91-R92) [[6]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R110-R111) [[7]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R129-R130) [[8]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R148-R149) [[9]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R167-R168) [[10]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R177-R178)