### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the workflow will now also run on all tags, in addition to the existing branches.