### PR TITLE
Remove trigger on tag post-merge.yml

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The `post-merge.yml` workflow will no longer be triggered by tags; it will only run on pushes to the `main` and `release-*` branches, or when manually triggered.

- Removed tag-based triggers from the `post-merge.yml` workflow, so it no longer runs on tag pushes.