### PR TITLE
Optimize bufio.NewScanner with bytes.NewReader

### DIFF
--- a/platform-manageability-agent/internal/comms/comms.go
+++ b/platform-manageability-agent/internal/comms/comms.go
@@ -5,6 +5,7 @@ package comms
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -142,7 +143,7 @@ func (cli *Client) IsActivationInProgress() bool {
 	return cli.isActivationInProgress.Load()
 }
 func parseAMTInfoField(output []byte, parseKey string) (string, bool) {
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	scanner := bufio.NewScanner(bytes.NewReader(output))
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/platform-update-agent/internal/utils/os_detection.go
+++ b/platform-update-agent/internal/utils/os_detection.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -28,7 +29,7 @@ func DetectOS(reader FileReader, forcedOS string) (string, error) {
 		return "", fmt.Errorf("failed to open /etc/os-release: %v", err)
 	}
 
-	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	scanner := bufio.NewScanner(bytes.NewReader(content))
 	var osId string
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description
Replaced `strings.NewReader(string(bytes))` with `bytes.NewReader(bytes)` for initializing `bufio.NewScanner`.

This avoids allocating and copying `[]byte` into a `string` before reading, which reduces memory usage and garbage collection overhead.



### Any Newly Introduced Dependencies

This optimization strictly relies on the Go standard library. Specifically, the change imports the standard library bytes package to replace the usage of the strings package in creating a new reader.

No external libraries or modules were added to the go.mod files of either platform-manageability-agent or platform-update-agent.
### How Has This Been Tested?

Here are the detailed steps to reproduce the testing and verify the changes:

1. Test the Platform Manageability Agent:

# Navigate to the agent's directory
cd platform-manageability-agent

# Run the test suite using the provided Makefile command
make test
Expected Result: The test output will show ok for github.com/open-edge-platform/edge-node-agents/platform-manageability-agent/internal/comms, confirming that parseAMTInfoField and IsActivationInProgress (which had changes) still function properly.

2. Test the Platform Update Agent:

# Navigate to the agent's directory
cd ../platform-update-agent

# Run the test suite using the provided Makefile command
make test
Expected Result: The test output will show ok for github.com/open-edge-platform/edge-node-agents/platform-update-agent/internal/utils, confirming that DetectOS accurately identifies the operating system string using the modified bufio.NewScanner mechanism.

Test Configuration Details:

The tests are run using standard Go testing tools invoked via Makefiles (make test maps to go test ./internal/... -race).
No special environmental variables or configurations are required to run these unit tests locally. The changes solely replace how an io.Reader is instantiated over an existing byte slice, so external dependencies or hardware requirements aren't a factor for this validation.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
